### PR TITLE
bugfix import and typo in user_id

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -9,6 +9,7 @@ use App\Eloquent\Voter;
 use Carbon\Carbon;
 use Firebase\JWT\JWT;
 use Illuminate\Http\Request;
+use Ramsey\Uuid\Uuid;
 
 class LoginController extends Controller
 {
@@ -28,7 +29,7 @@ class LoginController extends Controller
 
         $voter = Voter::create(["user_id" => $user->id, "code" => $code->code]);
 
-        return $this->generateAuthJwt(self::TYPE_VOTER, $voter->userId);
+        return $this->generateAuthJwt(self::TYPE_VOTER, $voter->user_id);
     }
 
     private function generateAuthJwt(string $type, string $userId): string


### PR DESCRIPTION
Fixes 2 bugs introduced in https://github.com/WesleyKlop/ipsen5/pull/36
- `userId` was typo'd, should be `user_id` instead.
- The required ramsey uuid library wasn't imported, imported it.