### PR TITLE
Add Spinner component

### DIFF
--- a/resources/js/components/Spinner.js
+++ b/resources/js/components/Spinner.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Spinner = () => (
+    <svg viewBox="0 0 100 100" className="spinner-container">
+        <circle cx="50" cy="50" r="45" className="spinner-circle"/>
+    </svg>
+)
+
+export default Spinner

--- a/resources/js/routes/PropositionPage.js
+++ b/resources/js/routes/PropositionPage.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import ProgressBar from '../components/ProgressBar'
+import Spinner from '../components/Spinner'
 
 const PropositionPage = () => (
     <>
         <div style={{ flex: '1' }}/>
-        {/*Content*/}
+        <div style={{ width: '100%', flex: '1', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Spinner/>
+        </div>
         <div style={{ flex: '2' }}/>
         <ProgressBar/>
     </>

--- a/resources/sass/Spinner.scss
+++ b/resources/sass/Spinner.scss
@@ -1,0 +1,51 @@
+@import 'variables';
+
+// SVG styles.
+.spinner-container {
+    animation: 2s linear infinite svg-animation;
+    height: 100px;
+    width: 100px;
+}
+
+// SVG animation.
+@keyframes svg-animation {
+    0% {
+        transform: rotateZ(0deg);
+    }
+    100% {
+        transform: rotateZ(360deg)
+    }
+}
+
+// Circle styles.
+.spinner-circle {
+    animation: 1.4s ease-in-out infinite both circle-animation;
+    display: block;
+    fill: transparent;
+    stroke: $accent-color;
+    stroke-linecap: round;
+    stroke-dasharray: 283;
+    stroke-dashoffset: 280;
+    stroke-width: 10px;
+    transform-origin: 50% 50%;
+}
+
+// Circle animation.
+@keyframes circle-animation {
+    0%,
+    25% {
+        stroke-dashoffset: 280;
+        transform: rotate(0);
+    }
+
+    50%,
+    75% {
+        stroke-dashoffset: 75;
+        transform: rotate(45deg);
+    }
+
+    100% {
+        stroke-dashoffset: 280;
+        transform: rotate(360deg);
+    }
+}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -7,6 +7,7 @@
 @import "Button";
 @import 'Input';
 @import 'ProgressBar';
+@import 'Spinner';
 
 // Global styles
 body {


### PR DESCRIPTION
Useful for loading. You could display the spinner before sending a http request (imagine component like this:

```js
class SomeComponent extends Component {
  state = {
    isLoading: true,
    data: []
  }

  onComponentMount() {
    fetch('/api/data').then(res => res.json()).then(data => {
      this.setState({ isLoading: false, data })
    }
  }

  render() {
    return (
      <div>
        {this.state.isLoading 
          ? <Spinner /> 
          : this.state.data.map(data => <DataComponent {...data} />)}
      </div>
    )
  }
}
```