### PR TITLE
Hotfix/invalid token

### DIFF
--- a/resources/js/Auth.js
+++ b/resources/js/Auth.js
@@ -3,7 +3,7 @@ import jwtDecode from 'jwt-decode'
 const Auth = {
     getJWT: () => sessionStorage.getItem('jwt'),
     isAuthenticated: () => Auth.getJWT() !== null,
-    isAuthorized: type => jwtDecode(Auth.getJWT()).sub.type === type,
+    isAuthorized: type => Auth.isAuthenticated() ? jwtDecode(Auth.getJWT()).sub.type === type : false,
     authenticate: jwt => sessionStorage.setItem('jwt', jwt['jwt']),
     signout: () => sessionStorage.removeItem('jwt'),
 }


### PR DESCRIPTION
Hotfix for issue #95 

Token was being decoded to check user type. This doesn't work if there isn't a token.
The fix

This was a case of bad testing which I'll learn from.

Closes #95